### PR TITLE
Add modified PETRv2-RepVGG-B0 training cfg

### DIFF
--- a/projects/configs/petrv2/petrv2_fcos3d_repvgg_b0x32_decoder_3_UN_1600x640.py
+++ b/projects/configs/petrv2/petrv2_fcos3d_repvgg_b0x32_decoder_3_UN_1600x640.py
@@ -1,0 +1,255 @@
+_base_ = [
+    '../../../mmdetection3d/configs/_base_/datasets/nus-3d.py',
+    '../../../mmdetection3d/configs/_base_/default_runtime.py'
+]
+backbone_norm_cfg = dict(type='LN', requires_grad=True)
+plugin=True
+plugin_dir='projects/mmdet3d_plugin/'
+
+# If point cloud range is changed, the models should also change their point
+# cloud range accordingly
+point_cloud_range = [-51.2, -51.2, -5.0, 51.2, 51.2, 3.0]
+voxel_size = [0.2, 0.2, 8]
+img_norm_cfg = dict(
+    mean=[103.530, 116.280, 123.675], std=[57.375, 57.120, 58.395], to_rgb=False)
+# For nuScenes we usually do 10-class detection
+class_names = [
+    'car', 'truck', 'construction_vehicle', 'bus', 'trailer', 'barrier',
+    'motorcycle', 'bicycle', 'pedestrian', 'traffic_cone'
+]
+input_modality = dict(
+    use_lidar=False,
+    use_camera=True,
+    use_radar=False,
+    use_map=False,
+    use_external=True)
+
+num_layers = 3
+model = dict(
+    type='Petr3D',
+    use_grid_mask=True,
+    img_backbone=dict(
+        type='RepVGG', ###use checkpoint to save memory
+        num_blocks=[4, 6, 16, 1],
+        width_multiplier=[1, 1, 1, 2.5],
+        override_groups_map=None,
+        out_indices=(2, 3),
+        deploy=False,
+        pretrained = 'ckpts/fcos3d_repvgg_h2_epoch_12_remapped.pth'
+        ),
+    img_neck=None,
+    pts_bbox_head=dict(
+        type='PETRv2Head',
+        position_level=1,
+        num_classes=10,
+        in_channels=1280,
+        num_query=900,
+        LID=True,
+        with_position=True,
+        with_multiview=True,
+        with_fpe=True,
+        with_time=True,
+        with_multi=True,
+        position_range=[-61.2, -61.2, -10.0, 61.2, 61.2, 10.0],
+        code_weights = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+        num_pred=num_layers,
+        transformer=dict(
+            type='PETRTransformer',
+            decoder=dict(
+                type='PETRTransformerDecoder',
+                return_intermediate=True,
+                num_layers=num_layers,
+                post_norm_cfg=None,
+                transformerlayers=dict(
+                    type='PETRTransformerDecoderLayer',
+                    attn_cfgs=[
+                        dict(
+                            type='MultiheadAttention',
+                            embed_dims=256,
+                            num_heads=8,
+                            dropout=0.1,
+                            ),
+                        dict(
+                            type='PETRMultiheadAttention',
+                            embed_dims=256,
+                            num_heads=8,
+                            dropout=0.1,
+                            ),
+                        ],
+                    norm_cfg=dict(type='UN'),
+                    feedforward_channels=2048,
+                    ffn_dropout=0.1,
+                    with_cp=True,  ###use checkpoint to save memory
+                    operation_order=('self_attn', 'norm', 'cross_attn', 'norm',
+                                     'ffn', 'norm')),
+            )),
+        bbox_coder=dict(
+            type='NMSFreeCoder',
+            post_center_range=[-61.2, -61.2, -10.0, 61.2, 61.2, 10.0],
+            pc_range=point_cloud_range,
+            max_num=300,
+            voxel_size=voxel_size,
+            num_classes=10), 
+        positional_encoding=dict(
+            type='SinePositionalEncoding3D', num_feats=128, normalize=True),
+        loss_cls=dict(
+            type='FocalLoss',
+            use_sigmoid=True,
+            gamma=2.0,
+            alpha=0.25,
+            loss_weight=2.0),
+        loss_bbox=dict(type='L1Loss', loss_weight=0.25),
+        loss_iou=dict(type='GIoULoss', loss_weight=0.0)),
+    # model training and testing settings
+    train_cfg=dict(pts=dict(
+        grid_size=[512, 512, 1],
+        voxel_size=voxel_size,
+        point_cloud_range=point_cloud_range,
+        out_size_factor=4,
+        assigner=dict(
+            type='HungarianAssigner3D',
+            cls_cost=dict(type='FocalLossCost', weight=2.0),
+            reg_cost=dict(type='BBox3DL1Cost', weight=0.25),
+            iou_cost=dict(type='IoUCost', weight=0.0), # Fake cost. This is just to make it compatible with DETR head. 
+            pc_range=point_cloud_range))))
+
+dataset_type = 'CustomNuScenesDataset'
+data_root = 'data/nuscenes/'
+
+file_client_args = dict(backend='disk')
+
+db_sampler = dict(
+    data_root=data_root,
+    info_path=data_root + 'nuscenes_dbinfos_train.pkl',
+    rate=1.0,
+    prepare=dict(
+        filter_by_difficulty=[-1],
+        filter_by_min_points=dict(
+            car=5,
+            truck=5,
+            bus=5,
+            trailer=5,
+            construction_vehicle=5,
+            traffic_cone=5,
+            barrier=5,
+            motorcycle=5,
+            bicycle=5,
+            pedestrian=5)),
+    classes=class_names,
+    sample_groups=dict(
+        car=2,
+        truck=3,
+        construction_vehicle=7,
+        bus=4,
+        trailer=6,
+        barrier=2,
+        motorcycle=6,
+        bicycle=6,
+        pedestrian=2,
+        traffic_cone=2),
+    points_loader=dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=5,
+        use_dim=[0, 1, 2, 3, 4],
+        file_client_args=file_client_args))
+ida_aug_conf = {
+        "resize_lim": (0.94, 1.25),
+        "final_dim": (640, 1600),
+        "bot_pct_lim": (0.0, 0.0),
+        "rot_lim": (0.0, 0.0),
+        "H": 900,
+        "W": 1600,
+        "rand_flip": True,
+    }
+train_pipeline = [
+    dict(type='LoadMultiViewImageFromFiles', to_float32=True),
+    dict(type='LoadMultiViewImageFromMultiSweepsFiles', sweeps_num=1, to_float32=True, pad_empty_sweeps=True, test_mode=False, sweep_range=[3,27]),
+    dict(type='LoadAnnotations3D', with_bbox_3d=True, with_label_3d=True, with_attr_label=False),
+    dict(type='ObjectRangeFilter', point_cloud_range=point_cloud_range),
+    dict(type='ObjectNameFilter', classes=class_names),
+    dict(type='ResizeCropFlipImage', data_aug_conf = ida_aug_conf, training=True),
+    dict(type='GlobalRotScaleTransImage',
+            rot_range=[-0.3925, 0.3925],
+            translation_std=[0, 0, 0],
+            scale_ratio_range=[0.95, 1.05],
+            reverse_angle=True,
+            training=True
+            ),
+    dict(type='NormalizeMultiviewImage', **img_norm_cfg),
+    dict(type='PadMultiViewImage', size_divisor=32),
+    dict(type='DefaultFormatBundle3D', class_names=class_names),
+    dict(type='Collect3D', keys=['gt_bboxes_3d', 'gt_labels_3d', 'img'],
+            meta_keys=('filename', 'ori_shape', 'img_shape', 'lidar2img', 'intrinsics', 'extrinsics',
+                'pad_shape', 'scale_factor', 'flip', 'box_mode_3d', 'box_type_3d',
+                'img_norm_cfg', 'sample_idx', 'timestamp'))
+]
+test_pipeline = [
+    dict(type='LoadMultiViewImageFromFiles', to_float32=True),
+    dict(type='LoadMultiViewImageFromMultiSweepsFiles', sweeps_num=1, to_float32=True, pad_empty_sweeps=True, sweep_range=[3,27]),
+    dict(type='ResizeCropFlipImage', data_aug_conf = ida_aug_conf, training=False),
+    dict(type='NormalizeMultiviewImage', **img_norm_cfg),
+    dict(type='PadMultiViewImage', size_divisor=32),
+    dict(
+        type='MultiScaleFlipAug3D',
+        img_scale=(1333, 800),
+        pts_scale_ratio=1,
+        flip=False,
+        transforms=[
+            dict(
+                type='DefaultFormatBundle3D',
+                class_names=class_names,
+                with_label=False),
+            dict(type='Collect3D', keys=['img'],
+            meta_keys=('filename', 'ori_shape', 'img_shape', 'lidar2img', 'intrinsics', 'extrinsics',
+                'pad_shape', 'scale_factor', 'flip', 'box_mode_3d', 'box_type_3d',
+                'img_norm_cfg', 'sample_idx', 'timestamp'))
+        ])
+]
+
+data = dict(
+    samples_per_gpu=1,
+    workers_per_gpu=4,
+    train=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file=data_root + 'mmdet3d_nuscenes_30f_infos_train.pkl',
+        pipeline=train_pipeline,
+        classes=class_names,
+        modality=input_modality,
+        test_mode=False,
+        use_valid_flag=True,
+        # we use box_type_3d='LiDAR' in kitti and nuscenes dataset
+        # and box_type_3d='Depth' in sunrgbd and scannet dataset.
+        box_type_3d='LiDAR'),
+    val=dict(type=dataset_type, pipeline=test_pipeline, ann_file=data_root + 'mmdet3d_nuscenes_30f_infos_val.pkl', classes=class_names, modality=input_modality),
+    test=dict(type=dataset_type, pipeline=test_pipeline, ann_file=data_root + 'mmdet3d_nuscenes_30f_infos_val.pkl', classes=class_names, modality=input_modality))
+
+
+optimizer = dict(
+    type='AdamW', 
+    lr=2e-4,
+    paramwise_cfg=dict(
+        custom_keys={
+            'img_backbone': dict(lr_mult=0.1),
+        }),
+    weight_decay=0.01)
+
+optimizer_config = dict(type='Fp16OptimizerHook', loss_scale=512., grad_clip=dict(max_norm=35, norm_type=2))
+
+# learning policy
+lr_config = dict(
+    policy='CosineAnnealing',
+    warmup='linear',
+    warmup_iters=500,
+    warmup_ratio=1.0 / 3,
+    min_lr_ratio=1e-3,
+    )
+total_epochs = 24*5
+evaluation = dict(interval=24, pipeline=test_pipeline)
+find_unused_parameters=False #### when use checkpoint, find_unused_parameters must be False
+checkpoint_config = dict(interval=1, max_keep_ckpts=3)
+runner = dict(type='EpochBasedRunner', max_epochs=total_epochs)
+load_from='ckpts/fcos3d_repvgg_h2_epoch_12_remapped.pth'
+resume_from=None
+

--- a/projects/configs/petrv2/petrv2_fcos3d_repvgg_b0x32_decoder_3_UN_1600x640.py
+++ b/projects/configs/petrv2/petrv2_fcos3d_repvgg_b0x32_decoder_3_UN_1600x640.py
@@ -253,3 +253,24 @@ runner = dict(type='EpochBasedRunner', max_epochs=total_epochs)
 load_from='ckpts/fcos3d_repvgg_h2_epoch_12_remapped.pth'
 resume_from=None
 
+# mAP: 0.3446
+# mATE: 0.8071
+# mASE: 0.2763
+# mAOE: 0.5319
+# mAVE: 0.4746
+# mAAE: 0.1857
+# NDS: 0.4447
+# Eval time: 184.4s
+
+# Per-class results:
+# Object Class    AP      ATE     ASE     AOE     AVE     AAE
+# car     0.545   0.572   0.152   0.076   0.403   0.189
+# truck   0.300   0.857   0.227   0.125   0.373   0.209
+# bus     0.373   0.835   0.193   0.117   1.041   0.258
+# trailer 0.107   1.138   0.255   0.613   0.370   0.044
+# construction_vehicle    0.049   1.102   0.499   1.431   0.145 0.389
+# pedestrian      0.455   0.718   0.300   0.599   0.507   0.184
+# motorcycle      0.322   0.788   0.259   0.656   0.638   0.199
+# bicycle 0.307   0.731   0.279   1.001   0.320   0.013
+# traffic_cone    0.543   0.559   0.322   nan     nan     nan
+# barrier 0.445   0.771   0.277   0.168   nan     nan 

--- a/projects/mmdet3d_plugin/models/dense_heads/petrv2_head.py
+++ b/projects/mmdet3d_plugin/models/dense_heads/petrv2_head.py
@@ -163,6 +163,7 @@ class PETRv2Head(AnchorFreeHead):
                  with_fpe=False,
                  with_time=False,
                  with_multi=False,
+                 num_pred=6,
                  **kwargs):
         # NOTE here use `AnchorFreeHead` instead of `TransformerHead`,
         # since it brings inconvenience when the initialization of
@@ -239,7 +240,7 @@ class PETRv2Head(AnchorFreeHead):
             f' and {num_feats}.'
         self.act_cfg = transformer.get('act_cfg',
                                        dict(type='ReLU', inplace=True))
-        self.num_pred = 6
+        self.num_pred = num_pred
         self.normedlinear = normedlinear
         self.with_fpe = with_fpe
         self.with_time = with_time

--- a/projects/mmdet3d_plugin/models/utils/__init__.py
+++ b/projects/mmdet3d_plugin/models/utils/__init__.py
@@ -9,12 +9,13 @@ from .detr import Deformable3DDetrTransformerDecoder
 from .detr3d_transformer import Detr3DTransformer, Detr3DTransformerDecoder, Detr3DCrossAtten
 from .positional_encoding import SinePositionalEncoding3D, LearnedPositionalEncoding3D
 from .petr_transformer import PETRTransformer, PETRDNTransformer, PETRMultiheadAttention, PETRTransformerEncoder, PETRTransformerDecoder
+from .unified_normalization import UN1d
 
 __all__ = ['DGCNNAttn', 'Deformable3DDetrTransformerDecoder', 
            'Detr3DTransformer', 'Detr3DTransformerDecoder', 'Detr3DCrossAtten'
            'SinePositionalEncoding3D', 'LearnedPositionalEncoding3D',
            'PETRTransformer', 'PETRDNTransformer', 'PETRMultiheadAttention', 
-           'PETRTransformerEncoder', 'PETRTransformerDecoder'
+           'PETRTransformerEncoder', 'PETRTransformerDecoder', 'UN1d'
            ]
 
 

--- a/projects/mmdet3d_plugin/models/utils/unified_normalization.py
+++ b/projects/mmdet3d_plugin/models/utils/unified_normalization.py
@@ -1,0 +1,212 @@
+# Copyright (c) Hangzhou Hikvision Digital Technology Co., Ltd. All rights reserved.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Abstract: Implementation of Unified Normalization
+"""
+
+import torch
+import torch.nn as nn
+from mmcv.cnn import NORM_LAYERS
+
+# implementation of FP/BP
+class UN2dFunction(torch.autograd.Function):
+    
+    @staticmethod
+    def forward(ctx, x, weight, bias, running_var, ema_gz, eps, momentum, buffer_x2, buffer_gz, iters, fp_buffer_size, bp_buffer_size, warmup_iters, outlier_filtration, skip_counter, mask_x):
+        ctx.eps = eps
+        ctx.bp_buffer_size = bp_buffer_size
+        current_iter = iters.item()
+        ctx.current_iter = current_iter
+        ctx.warmup_iters = warmup_iters
+        ctx.momentum = momentum
+
+        skip = False if fp_buffer_size > 1 else True
+
+        B, C, H, W = x.size()
+        x2 = (mask_x * mask_x).mean(dim=0)
+
+        # outlier
+        recorded_var = torch.var(torch.sqrt(buffer_x2))                                 # variance of sequence {sqrt(x2)}
+        buffer_x2[current_iter % fp_buffer_size].copy_(x2)                              # update buffer
+        if current_iter >= warmup_iters and outlier_filtration:
+            am = buffer_x2.mean(dim=0).view(1, C, 1, 1)                                 # arithmetic mean
+            gm = torch.exp(torch.mean(torch.log(buffer_x2), dim=0)).view(1, C, 1, 1)    # geometric mean
+            diff = am - gm
+            if (diff > recorded_var * fp_buffer_size).sum() > 0:                        # compare with recorded variance
+                # skip current batch, and update buffer with running statistic
+                buffer_x2[current_iter % fp_buffer_size].copy_(running_var.view(-1))
+                skip = True
+                skip_counter.copy_(skip_counter+1)          # counting
+
+        if current_iter <= fp_buffer_size or current_iter < warmup_iters or skip:
+            var = x2.view(1, C, 1, 1)
+        else:
+            var = torch.exp(torch.mean(torch.log(buffer_x2), dim=0)).view(1, C, 1, 1)   # numerically-stable version of the geometric mean
+        
+        # pass the scale to BP
+        r = (var + eps).sqrt() / (running_var + eps).sqrt()
+        if current_iter <= max(1000, warmup_iters) or skip:
+            r = torch.clamp(r, 1, 1)
+        else:
+            r = torch.clamp(r, 1/5, 5)
+        
+        z = x /(var + eps).sqrt()
+
+        ctx.smas_skip = skip
+        ctx.save_for_backward(z, var, weight, buffer_gz, ema_gz, r)
+        
+        running_var.copy_(momentum*running_var + (1-momentum)*var)
+
+        y = weight.view(1,C,1,1) * z + bias.view(1,C,1,1)
+        return y
+    
+    @staticmethod
+    def backward(ctx, grad_output):
+        eps = ctx.eps
+        bp_buffer_size = ctx.bp_buffer_size
+        current_iter = ctx.current_iter
+        warmup_iters = ctx.warmup_iters
+        momentum = ctx.momentum
+        smas_skip = ctx.smas_skip
+
+        N, C, H, W = grad_output.size()
+        z, var, weight, buffer_gz, ema_gz, r = ctx.saved_variables
+
+        # gradient compensation
+        y = r * z
+        g = grad_output * weight.view(1, C, 1, 1)
+        g = g * r
+        gz = (g * z).mean(dim=3).mean(dim=2).mean(dim=0)
+        
+        if smas_skip:
+            buffer_gz[current_iter % bp_buffer_size].copy_(ema_gz.view(-1))
+        else:
+            buffer_gz[current_iter % bp_buffer_size].copy_(gz)
+        
+        if current_iter <= bp_buffer_size or current_iter < warmup_iters or smas_skip:
+            mean_gz = gz.view(1, C, 1, 1)
+        else:
+            mean_gz = buffer_gz.mean(dim=0).view(1, C, 1, 1)
+        
+        ema_gz.copy_(ema_gz * momentum + (1 - momentum) * mean_gz)
+        if smas_skip:
+            approx_grad_g = (g - (mean_gz * z))
+        else:
+            approx_grad_g = (g - (ema_gz * z))
+
+        gx = 1. / torch.sqrt(var + eps) * approx_grad_g 
+        return gx, (grad_output * y).sum(dim=3).sum(dim=2).sum(dim=0), grad_output.sum(dim=3).sum(dim=2).sum(dim=0),  None, None, None, None, None, None, None, None, None, None, None, None, None
+
+
+@NORM_LAYERS.register_module('UN')
+class UN1d(nn.Module):
+    """
+    Args:
+        channels: :math:`C` from an expected input of size :math:`(B, N, C)`
+        window_size: the window size to save batch statistics from last several iterations.
+            default: 4
+        warmup_iters: the number of iterations before using moving average strategies to normalize input.
+            Default: 4000
+        outlier_filtration: adaptive threshold for applying moving averaging strategies in FP/BP; Suggest to set as False for NLP tasks, and True for CV tasks.
+            Default: False
+        eps: a small value added to the denominator for numerical stability.
+            Default: 1e-5
+        momentum: the value used for the exponential moving average. 
+            It should be in the limit of :math`(0, 1)`. 
+            Default: 0.9
+    """
+    def __init__(self, channels, window_size=4, warmup_iters=4000, outlier_filtration=True, eps=1e-5, momentum=0.9):
+        super(UN1d, self).__init__()
+        assert (isinstance(window_size, int) 
+                or (isinstance(window_size, list) and len(window_size) == 2)
+                or isinstance(window_size, tuple)), "window_size should be in the type of int/list/tuple, but got {} {}".format(type(window_size), window_size)
+        
+        if isinstance(window_size, int):
+            self.fp_buffer_size = window_size
+            self.bp_buffer_size = window_size
+        else:
+            self.fp_buffer_size = window_size[0]
+            self.bp_buffer_size = window_size[1]
+        
+        self.register_parameter('weight', nn.Parameter(torch.ones(channels)))
+        self.register_parameter('bias', nn.Parameter(torch.zeros(channels)))
+        self.register_buffer('running_var', torch.ones(channels))
+        self.register_buffer('ema_gz', torch.zeros(channels))
+        self.register_buffer('iters', torch.zeros(1).type(torch.LongTensor))
+        self.register_buffer('buffer_x2', torch.zeros(self.fp_buffer_size, channels))
+        self.register_buffer('buffer_gz', torch.zeros(self.bp_buffer_size, channels))
+
+        self.num_features = channels
+        
+        self.eps = eps
+        self.momentum = momentum
+        self.warmup_iters = warmup_iters
+        self.outlier_filtration = outlier_filtration
+        self.register_buffer('skip_counter', torch.zeros(1).type(torch.LongTensor))
+    
+    def extra_repr(self):
+        return '{num_features}, fp_win={fp_buffer_size}, bp_win={bp_buffer_size}, eps={eps}, momentum={momentum}, warmup={warmup_iters}, outlier_filtration={outlier_filtration}'.format(**self.__dict__)
+
+    def forward(self, x, pad_mask=None):
+        """
+        input:  B x N x C
+        pad_mask: B x N (padding is True)
+        """
+
+        assert pad_mask is None # TODO remove pad_mask
+
+        shaped_input = (len(x.shape) == 2)
+        if shaped_input:
+            x = x.unsqueeze(0)
+        # B, N, C = x.shape
+        N, B, C = x.shape
+        x = x.permute(1, 0, 2)
+
+        # construct the mask_input, size to be (BxN) x C: N is the real length here
+        if pad_mask is None:
+            mask_input = x.clone()
+        else:
+            bn_mask = ~pad_mask
+            # mask_input = x[bn_mask, :]
+            mask_input = x[bn_mask, :]
+            
+        
+        mask_input = mask_input.reshape(-1, self.num_features)
+        
+        if self.training:
+            x = x.permute(0, 2, 1).contiguous()                 # BxNxC -> BxCxN
+            input_shape = x.size()
+            x = x.reshape(x.size(0), self.num_features, -1)     # BxCxN -> BxCxNx1
+            x = x.unsqueeze(-1)
+            
+            self.iters.copy_(self.iters + 1)
+            x = UN2dFunction.apply(x, self.weight, self.bias, self.running_var.view(1,self.num_features,1,1), self.ema_gz.view(1,self.num_features,1,1),
+                                      self.eps, self.momentum, self.buffer_x2, self.buffer_gz, self.iters,
+                                      self.fp_buffer_size, self.bp_buffer_size, self.warmup_iters, self.outlier_filtration, self.skip_counter,
+                                      mask_input)            
+            x = x.reshape(input_shape)
+            x = x.permute(0, 2, 1).contiguous()
+            
+            # Reshape it.
+            if shaped_input:
+                x = x.squeeze(0)
+        
+        else:
+            var = self.running_var
+            x = x / (var + self.eps).sqrt()
+            x = self.weight * x + self.bias
+
+        return x.permute(1, 0, 2)


### PR DESCRIPTION
- add repvgg-b0 backbone petrv2 model:
     -  3 decoding layers
     - UnifiedNorm instead of LayerNorm
     - 1600x640 input resolution
     - x32 backbone stride